### PR TITLE
Update: 修改 Biz 字段说明

### DIFF
--- a/cn.zh-CN/开发指南/服务端API/API说明文档/发起认证请求.md
+++ b/cn.zh-CN/开发指南/服务端API/API说明文档/发起认证请求.md
@@ -29,7 +29,7 @@
 |--|--|----|----|--|
 |Action|String|query|是|要执行的操作。取值：GetVerifyToken。|
 |RegionId|String|query|是|服务所在地域。取值：cn-hangzhou。|
-|Biz|String|query|是|使用实人认证服务的业务场景。请先参考[业务设置](https://help.aliyun.com/document_detail/59975.html)在控制台完成创建。|
+|Biz|String|query|是|使用实人认证服务的业务场景标识名。请先参考[业务设置](https://help.aliyun.com/document_detail/59975.html)在控制台完成创建。|
 |TicketId|String|query|是|标识一次认证任务的唯一ID。通常由业务使用方指定，方便关联业务场景的其他内容。一次认证任务，系统支持无限次发起提交，直到最终认证通过，该任务完结。**说明：** 发起不同的认证任务时需要更换不同的认证 ID。
 
 |


### PR DESCRIPTION
在使用的时候没看懂 Biz 代表的意思，然后去下面的接口寻找示例，发现 Biz 值设置为 `RPBasic `，
这个值会让人以为是云盾实人认证的 `认证方案` 一值，而实际应该设置的值为`场景标识`，很容易让人产生误导。

接口示例：
![image](https://user-images.githubusercontent.com/10390004/61424613-a7d3ef00-a946-11e9-84d3-d50bc4325cae.png)
云盾实人认证，认证方案：
![image](https://user-images.githubusercontent.com/10390004/61424594-9d195a00-a946-11e9-8ef0-4acfe7501d1c.png)
